### PR TITLE
Add option to color accuracy text depending on if a PB is possible anymore (yellow/orange) or not (red)

### DIFF
--- a/ColorBehavior.cs
+++ b/ColorBehavior.cs
@@ -1,0 +1,43 @@
+namespace HighscoreAccuracy;
+
+public enum ColorBehavior
+{
+    /// <summary>
+    /// Color depends on how close you are to your PB
+    /// </summary>
+    /// <remarks>
+    /// <ul>
+    ///     <li>Green: Above PB</li>
+    ///     <li>Yellow: Up to 10% below PB</li>
+    ///     <li>Red: More than 10% below PB</li>
+    /// </ul>
+    /// </remarks>
+    Closeness,
+
+    /// <summary>
+    /// Color depends on whether a PB is possible or not
+    /// </summary>
+    /// <remarks>
+    /// <ul>
+    ///     <li>Dark green: Above PB and cannot avoid setting a new PB</li>
+    ///     <li>Light green: Above PB</li>
+    ///     <li>Yellow: PB is still possible with the remaining notes left</li>
+    ///     <li>Red: PB is impossible</li>
+    /// </ul>
+    /// </remarks>
+    PbPossibility,
+
+    /// <summary>
+    /// A combination of the above two
+    /// </summary>
+    /// <remarks>
+    /// <ul>
+    ///     <li>Dark green: Above PB and cannot avoid setting a new PB</li>
+    ///     <li>Light green: Above PB</li>
+    ///     <li>Yellow: PB is still possible with the remaining notes left</li>
+    ///     <li>Orange: PB is still possible with the remaining notes left, but you're more than 10% below PB</li>
+    ///     <li>Red: PB is impossible</li>
+    /// </ul>
+    /// </remarks>
+    Hybrid,
+}

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ Adds accuracy information to level select and when playing
 - [BaboonAPI](https://github.com/tc-mods/BaboonAPI)
 
 ## Changelog
+Unreleased
+- Add option to change text color based on how close you are to a PB (old behavior), whether a PB is possible anymore, or a combination of the two (the new default)
+
 v.1.3.7
 - Fix for new scoring system in TC 1.20
 - Fix % sometimes not showing on points screen

--- a/Utils.cs
+++ b/Utils.cs
@@ -21,6 +21,19 @@ public static class Utils
 
     public static int GetMaxScore(AccType accType, List<float[]> levelData) => GetScoreSums(accType, levelData)[levelData.Count - 1];
 
+    /// <summary>
+    /// Get an array of the max scores attainable at each note of the chart
+    /// </summary>
+    /// <remarks>
+    /// For example, if we have a chart with 3 notes worth 100, 200, and 300 points each, this array will contain...
+    /// <code>
+    /// {
+    ///     100,
+    ///     300, // (100 + 200)
+    ///     600, // (100 + 200 + 300)
+    /// }
+    /// </code>
+    /// </remarks>
     public static int[] GetScoreSums(AccType accType, List<float[]> levelData)
     {
         int[] scoreSums = new int[levelData.Count];
@@ -29,6 +42,7 @@ public static class Utils
         float minimumNoteGap = .025f;
         for (int i = 0; i < levelData.Count; i++)
         {
+            // Go through this note and all connected ones to total up their length
             var length = levelData[i][1];
             while (i + 1 < levelData.Count && levelData[i][0] + levelData[i][1] + minimumNoteGap >= levelData[i + 1][0])
             {
@@ -36,6 +50,7 @@ public static class Utils
                 scoreSums[i] = scoreTotal;
                 i++;
             }
+
             var score = accType == AccType.BaseGame ? GetGameMax(length) : GetRealMax(length, index);
             scoreTotal += score;
             scoreSums[i] = scoreTotal;


### PR DESCRIPTION
This adds "Color behavior" as an option, which can be
- Closeness (the old Highscore Accuracy behavior)
- PB Possibility (Green when above PB, Yellow when below but can still PB, Red when you can't)
- Hybrid (A combination of the two above, Green when above PB, Yellow when below but can still PB, Orange when more than 10% below but can still PB, Red when you can't) - made this the new default for now

Also the odd doc comment, and a little rejiggering the settings labels so it's not one massive wall of text at the bottom.

This (effectively) depends on https://github.com/TootTally/TootTallySettings/pull/1
(I mean, technically it doesn't, but labels will be massively overlapping without it)

![image](https://github.com/emmett-shark/HighscoreAccuracy/assets/5341220/eb56b628-28a7-40b7-a7a2-926e302c3bc6)
